### PR TITLE
Inkscape is now run in our own custom home dir.

### DIFF
--- a/inkscape-context/.config/inkscape/preferences.xml
+++ b/inkscape-context/.config/inkscape/preferences.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<inkscape
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	version="1">
+	<group id="options">
+  </group>
+</inkscape>

--- a/inkscape-context/.local/share/README.md
+++ b/inkscape-context/.local/share/README.md
@@ -1,0 +1,1 @@
+This page intentionally left blank.

--- a/inkscape-context/README.md
+++ b/inkscape-context/README.md
@@ -1,0 +1,1 @@
+Before the build applies Inkscape to any generated shapes, this directory is copied into the build directory and the copy used as the `$HOME` dir for Inkscape. This allows the use of project-specific Inkscape settings, and it incidentally seems to reduce the amount of time Inkscape takes to run during the build.


### PR DESCRIPTION
Before the build applies Inkscape to any generated shapes, the new `inkscape-context` directory is copied into the build directory and the copy used as the `$HOME` dir when running Inkscape. This allows the use of project-specific Inkscape settings and gives Inkscape a `.local/share` dir to toss ancillary information into (this was necessary on my system to suppress an error message).

Doing this incidentally seems to reduce the time Inkscape takes to run during the build by a small noticeable amount.